### PR TITLE
Add booter description

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ runtime memory. This quirk attempts to unify contiguous slots of similar types t
 
 ![Booter_fix_NVRAM](https://i.imgur.com/EFfgHjZ.jpg)
 **If NVRAM read/write problems occur, they can be resolved as follows:**
+
 **AvoidRuntimeDefrag** : Set to YES for Enabled NVRAM Reading.
 **EnableWriteUnprotector** : Set to YES for Enabled NVRAM Writing.
 

--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ operating system for security reasons. **Default Value is False/NO**
 **ShrinkMemoryMap** : Select firmwares have very large memory maps, which do not fit Apple kernel, permitting up to 64 slots for
 runtime memory. This quirk attempts to unify contiguous slots of similar types to prevent boot failures. **Default Value is False/NO**
 
-(https://i.imgur.com/EFfgHjZ.jpg)
+![Booter_fix_NVRAM](https://i.imgur.com/EFfgHjZ.jpg)
 If NVRAM read/write problems occur, they can be resolved as follows:
-**AvoidRuntimeDefrag** : Set to YES for Enabled NVRAM Reading
-**EnableWriteUnprotector** : Set to YES for Enabled NVRAM Writing
+**AvoidRuntimeDefrag** : Set to YES for Enabled NVRAM Reading.
+**EnableWriteUnprotector** : Set to YES for Enabled NVRAM Writing.
 
 * NVRAM read tests should display the NVRAM information in the Hackin tool/NVRAM correctly.
 * NVRAM write testing shall ensure that the starting disk  was correctly. (Default name was must be Macintosh HD)

--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ operating system for security reasons. **Default Value is False/NO**
 **ShrinkMemoryMap** : Select firmwares have very large memory maps, which do not fit Apple kernel, permitting up to 64 slots for
 runtime memory. This quirk attempts to unify contiguous slots of similar types to prevent boot failures. **Default Value is False/NO**
 
+* If NVRAM read/write problems occur, they can be resolved as follows:
+**AvoidRuntimeDefrag** : Set to YES for Enabled NVRAM Reading
+**EnableWriteUnprotector** : Set to YES for Enabled NVRAM Writing
+* NVRAM read tests should display the NVRAM information in the Hackin tool/NVRAM correctly.
+* NVRAM write testing shall ensure that the starting disk  was correctly. (Default boot disk name must be Macintosh HD)
+* Tested on Asus X299, Z370M-Plus II, and Gigabyte Z370 AORUS Gaming 5 and 7.
+
 
 # DeviceProperties
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ operating system for security reasons. **Default Value is False/NO**
 runtime memory. This quirk attempts to unify contiguous slots of similar types to prevent boot failures. **Default Value is False/NO**
 
 ![Booter_fix_NVRAM](https://i.imgur.com/EFfgHjZ.jpg)
-If NVRAM read/write problems occur, they can be resolved as follows:
+**If NVRAM read/write problems occur, they can be resolved as follows:**
 **AvoidRuntimeDefrag** : Set to YES for Enabled NVRAM Reading.
 **EnableWriteUnprotector** : Set to YES for Enabled NVRAM Writing.
 

--- a/README.md
+++ b/README.md
@@ -158,14 +158,15 @@ operating system for security reasons. **Default Value is False/NO**
 **ShrinkMemoryMap** : Select firmwares have very large memory maps, which do not fit Apple kernel, permitting up to 64 slots for
 runtime memory. This quirk attempts to unify contiguous slots of similar types to prevent boot failures. **Default Value is False/NO**
 
+
+
 **If NVRAM read/write problems occur, they can be resolved as follows:**
 
 **AvoidRuntimeDefrag** : Set to YES for Enabled NVRAM Reading
-
 **EnableWriteUnprotector** : Set to YES for Enabled NVRAM Writing
 
 * NVRAM read tests should display the NVRAM information in the Hackin tool/NVRAM correctly.
-* NVRAM write testing shall ensure that the starting disk  was correctly. (Default boot disk name must be Macintosh HD)
+* NVRAM write testing shall ensure that the starting disk  was correctly. (Default name was must be Macintosh HD)
 * Tested on Asus X299, Z370M-Plus II, and Gigabyte Z370 AORUS Gaming 5 and 7.
 
 

--- a/README.md
+++ b/README.md
@@ -158,9 +158,12 @@ operating system for security reasons. **Default Value is False/NO**
 **ShrinkMemoryMap** : Select firmwares have very large memory maps, which do not fit Apple kernel, permitting up to 64 slots for
 runtime memory. This quirk attempts to unify contiguous slots of similar types to prevent boot failures. **Default Value is False/NO**
 
-* If NVRAM read/write problems occur, they can be resolved as follows:
+**If NVRAM read/write problems occur, they can be resolved as follows:**
+
 **AvoidRuntimeDefrag** : Set to YES for Enabled NVRAM Reading
+
 **EnableWriteUnprotector** : Set to YES for Enabled NVRAM Writing
+
 * NVRAM read tests should display the NVRAM information in the Hackin tool/NVRAM correctly.
 * NVRAM write testing shall ensure that the starting disk  was correctly. (Default boot disk name must be Macintosh HD)
 * Tested on Asus X299, Z370M-Plus II, and Gigabyte Z370 AORUS Gaming 5 and 7.

--- a/README.md
+++ b/README.md
@@ -158,10 +158,8 @@ operating system for security reasons. **Default Value is False/NO**
 **ShrinkMemoryMap** : Select firmwares have very large memory maps, which do not fit Apple kernel, permitting up to 64 slots for
 runtime memory. This quirk attempts to unify contiguous slots of similar types to prevent boot failures. **Default Value is False/NO**
 
-
-
-'If NVRAM read/write problems occur, they can be resolved as follows:'
-
+(https://i.imgur.com/EFfgHjZ.jpg)
+If NVRAM read/write problems occur, they can be resolved as follows:
 **AvoidRuntimeDefrag** : Set to YES for Enabled NVRAM Reading
 **EnableWriteUnprotector** : Set to YES for Enabled NVRAM Writing
 

--- a/README.md
+++ b/README.md
@@ -159,12 +159,13 @@ operating system for security reasons. **Default Value is False/NO**
 runtime memory. This quirk attempts to unify contiguous slots of similar types to prevent boot failures. **Default Value is False/NO**
 
 ![Booter_fix_NVRAM](https://i.imgur.com/EFfgHjZ.jpg)
-```If NVRAM read/write problems occur, they can be resolved as follows:**```
+```If NVRAM read/write problems occur, they can be resolved as follows```
 
 **AvoidRuntimeDefrag** : Set to YES for Enabled NVRAM Reading.
 
 **EnableWriteUnprotector** : Set to YES for Enabled NVRAM Writing.
 
+![Booter_fix_NVRAM_verified](https://i.imgur.com/6ACmHDZ.jpg)
 * NVRAM read tests should display the NVRAM information in the Hackin tool/NVRAM correctly.
 * NVRAM write testing shall ensure that the starting disk  was correctly. (Default name was must be Macintosh HD)
 * Tested on Asus X299, Z370M-Plus II, and Gigabyte Z370 AORUS Gaming 5 and 7.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ runtime memory. This quirk attempts to unify contiguous slots of similar types t
 
 
 
-**If NVRAM read/write problems occur, they can be resolved as follows:**
+'If NVRAM read/write problems occur, they can be resolved as follows:'
 
 **AvoidRuntimeDefrag** : Set to YES for Enabled NVRAM Reading
 **EnableWriteUnprotector** : Set to YES for Enabled NVRAM Writing

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ runtime memory. This quirk attempts to unify contiguous slots of similar types t
 * NVRAM read tests should display the NVRAM information in the Hackin tool/NVRAM correctly.
 * NVRAM write testing shall ensure that the starting disk  was correctly. (Default name was must be Macintosh HD)
 * Tested on Asus X299, Z370M-Plus II, and Gigabyte Z370 AORUS Gaming 5 and 7.
+* This feature is based on an OpenCore 0.0.4 08082018 distribution and works with the FwRuntimeService.efi driver.
 
 
 # DeviceProperties

--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ operating system for security reasons. **Default Value is False/NO**
 runtime memory. This quirk attempts to unify contiguous slots of similar types to prevent boot failures. **Default Value is False/NO**
 
 ![Booter_fix_NVRAM](https://i.imgur.com/EFfgHjZ.jpg)
-**If NVRAM read/write problems occur, they can be resolved as follows:**
+```If NVRAM read/write problems occur, they can be resolved as follows:**```
 
 **AvoidRuntimeDefrag** : Set to YES for Enabled NVRAM Reading.
+
 **EnableWriteUnprotector** : Set to YES for Enabled NVRAM Writing.
 
 * NVRAM read tests should display the NVRAM information in the Hackin tool/NVRAM correctly.


### PR DESCRIPTION
Add Booter description for fix up NVRAM problem if found.

* tested on ASUS X299 TUF mk1, Deluxe, Deluxe II, Z370M-Plus II
* tested on Gigabyte Z370 AORUS Gaming 7 and 5

** how to enabled NVRAM Reading and Writing without VariableRuntimeDXE or Legacy NVRAM options.
