### PR TITLE
Clarify placement of sample.plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Place necessary .efi drivers from AppleSupportPkg and AptioFixPkg into the *driv
 
 While sharing the name, the config.plist in OpenCore, is very different from Clover config.plist, they **cannot** be mixed and matched. It is also not recommended to duplicate every patch and option from your clover config. 
 
-First, duplicate the `sample.plist`, rename it to `config.plist` and open in your .plist editor of choice.
+First, duplicate the `sample.plist` (found in OpenCorePks's Doc directory), rename it to `config.plist` and open in your .plist editor of choice.
 
 
 The config contains a number of sections:


### PR DESCRIPTION
Normally I'd be looking for the `sample.plist` file in the root directory of OC. It wasn't immediately obvious to me where to look for it, had to come up to Github and do a file search.

Hopefully this will save a few minutes for others in the future.